### PR TITLE
MySQLにfielsテーブル、study_logsテーブルを追加

### DIFF
--- a/Docker/MySQL/init.sql
+++ b/Docker/MySQL/init.sql
@@ -9,8 +9,29 @@ SET NAMES utf8mb4;
 
 CREATE TABLE users(
     user_id VARCHAR(36) PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
     email VARCHAR(255) UNIQUE NOT NULL,
     password VARCHAR(255) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAUlT CURRENT_TIMESTAMP
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE fields(
+    field_id INT PRIMARY KEY,
+    fieldname VARCHAR(20) NOT NULL,
+    color_code VARCHAR(7) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAUlT CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE study_logs(
+    study_log_id INT PRIMARY KEY,
+    study_date DATE NOT NULL,
+    hours DECIMAL(6,1) NOT NULL,
+    field_id INT NOT NULL,
+    FOREIGN KEY (field_id) REFERENCES fields(field_id) ON DELETE CASCADE,
+    content TEXT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+
 

--- a/Docker/MySQL/my.cnf
+++ b/Docker/MySQL/my.cnf
@@ -3,7 +3,7 @@ default-character-set = utf8mb4
 
 [mysqld]
 character-set-server = utf8mb4
-collation-server = utf8mb4_bin
+collation-server = utf8mb4_unicode_ci
 default-time-zone = 'Asia/Tokyo'
 
 [client]


### PR DESCRIPTION
事前に作成したER図に基づき、MySQLのinit.sqlにfielsテーブル、study_logsテーブルを追加した。 また、usersテーブルの内容を見直し、usernameカラムを追加した。
my.cnfのmysqld(server)の設定を、大文字・小文字を区別しないよう、utf8mb4_unicode_ciとした。