### PR TITLE
パスワード再設定機能を追加

### DIFF
--- a/myapp/templates/password_reset.html
+++ b/myapp/templates/password_reset.html
@@ -2,4 +2,31 @@
 
 {% block title %} パスワード再設定 {% endblock %}
 
-{% block content %} <h1>パスワード再設定画面</h1> {% endblock %}
+{% block content %}
+    {% with messages = get_flashed_messages() %}
+    {% if messages %}
+    <div class="flashes">
+        {% for message in messages %}
+        <p>{{ message }}</p>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+    <h1>パスワード再設定画面</h1><br>
+    <div>
+        <form action="{{ url_for('password_reset_process') }}" method="post">
+            <label for="email">メールアドレス：</label>
+            <input placeholder="メールアドレス" type="email" id="email" name="email"><br>
+
+            <label for="new_password1">新しいパスワード：</label>
+            <input placeholder="新しいパスワード" type="password" id="new_password1" name="new_password1"><br>
+
+            <label for="new_password2">新しいパスワード（確認用）：</label>
+            <input placeholder="新しいパスワード（確認用）" type="password" id="new_password2" name="new_password2"><br>
+
+            <div>
+                <button class="password_reset" type="submit">パスワード再設定</button>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/myapp/views.py
+++ b/myapp/views.py
@@ -1,10 +1,15 @@
 from flask import request, render_template, redirect, url_for, flash
 from flask_login import login_user, login_required, logout_user, current_user
+from flask_bcrypt import generate_password_hash, check_password_hash
 from .app import app, db
 from .models import User, Field, StudyLog
 from datetime import datetime, date
 import re
 import uuid
+
+# 定数定義
+EMAIL_PATTERN = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9.]+$'
+PASSWORD_PATTERN = r'^.{8,16}$'
 
 # ルーティング
 # ログイン画面
@@ -26,16 +31,13 @@ def signup_process():
     password1 = request.form.get('password1')
     password2 = request.form.get('password2')
 
-    email_pattern = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9.]+$'
-    password_pattern = r'^.{8,16}$'
-
     if username == '' or email == '' or password1 == '' or password2 == '':
         flash('空のフォームがあります')
     elif password1 != password2:
         flash('パスワードが一致しません')
-    elif re.match(email_pattern, email) is None:
+    elif re.match(EMAIL_PATTERN, email) is None:
         flash('メールアドレスの形式になっていません')
-    elif re.match(password_pattern, password1) is None:
+    elif re.match(PASSWORD_PATTERN, password1) is None:
         flash('パスワードは8文字以上16文字以内で入力してください')
     else:
         user_id = uuid.uuid4()
@@ -62,7 +64,37 @@ def signup_process():
             return redirect(url_for('login_view'))
     return redirect(url_for('signup_view'))
 
-# パスワード再設定画面
+# パスワード再設定
 @app.route('/password-reset', methods=['GET'])
 def password_reset_view():
     return render_template('password_reset.html')
+
+@app.route('/password-reset', methods=['POST'])
+def password_reset_process():
+    email = request.form.get('email')
+    new_password1 = request.form.get('new_password1')
+    new_password2 = request.form.get('new_password2')
+
+    if email == '' or new_password1 == '' or new_password2 == '':
+        flash('空のフォームがあります')
+    elif new_password1 != new_password2:
+        flash('パスワードが一致しません')
+    elif re.match(EMAIL_PATTERN, email) is None:
+        flash('メールアドレスの形式になっていません')
+    elif re.match(PASSWORD_PATTERN, new_password1) is None:
+        flash('パスワードは8文字以上16文字以内で入力してください')
+    else:
+        DBuser = User.select_by_email(email)
+        if DBuser == None:
+            flash('登録されていないメールアドレスです') 
+        else:
+            try:
+                DBuser.password = generate_password_hash(new_password1)
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
+            finally:
+                db.session.close()
+            return redirect(url_for('login_view'))
+    return redirect(url_for('password_reset_view'))


### PR DESCRIPTION
views.pyにパスワード再設定のロジックを記述し、password_reset.htmlにフォーム送信を追加した。 email,new_password1,new_password2のフォームを受取り、すでに登録済みのemailと照合し、登録済みのemailがあればDBから該当するレコードを取得する。 取得したDBレコードのpasswordをnew_password1に置き換えて更新する。
もし、emailが照合しなければ、「登録されていないメールアドレス」と返す。
ハッシュ化したパスワードで格納するため、generate_password_hashをインポートして、new_password1をハッシュ化している。