### PR TITLE
認証後の各画面へのルーティング設定

### DIFF
--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -13,7 +13,7 @@
         {% endif %}
     {% endwith %}
 
-    <h1>ホーム画面</h1>
+    <h1>{{ current_user.username }}さんのホーム画面</h1>
     <div>
         <form action="{{ url_for('logout') }}" method="get">
             <label for="logout"></label>
@@ -21,5 +21,17 @@
                 <button class="logout" type="submit">ログアウト</button>
             </div>
         </form>
+    </div>
+    <div class="mypage">
+        <a href="{{ url_for('mypage_view', user_id=current_user.user_id) }}">マイページ</a>
+    </div>
+    <div class="study_logs">
+        <a href="{{ url_for('study_logs_view', user_id=current_user.user_id) }}">学習登録</a>
+    </div>
+    <div class="study_fields">
+        <a href="{{ url_for('study_fields_view', user_id=current_user.user_id) }}">学習分野</a>
+    </div>
+    <div class="study_logs_list">
+        <a href="{{ url_for('study_logs_list', user_id=current_user.user_id) }}">学習履歴一覧</a>
     </div>
 {% endblock %}

--- a/myapp/templates/login.html
+++ b/myapp/templates/login.html
@@ -26,5 +26,12 @@
             </div>
         </form>
     </div>
+    <div class="signup">
+        <a href="{{ url_for('signup_view') }}">新規登録はこちら</a>
+    </div>
+    <div class="password_reset">
+        <a href="{{ url_for('password_reset_view') }}">パスワードをお忘れの方はこちら</a>
+    </div>
+
 {% endblock %}
 

--- a/myapp/templates/mypage.html
+++ b/myapp/templates/mypage.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block title %} マイページ {% endblock %}
+
+{% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="flashes">
+                {% for message in messages %}
+                    <p>{{ message }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    <h1>{{ current_user.username }}さんのマイページ</h1>
+    <div class="mypage_edit">
+        <a href="{{ url_for('mypage_edit_view', user_id=current_user.user_id) }}">マイページ編集</a>
+
+    </div>
+
+{% endblock %}

--- a/myapp/templates/mypage_edit.html
+++ b/myapp/templates/mypage_edit.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %} マイページ編集 {% endblock %}
+
+{% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="flashes">
+                {% for message in messages %}
+                    <p>{{ message }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    <h1>{{ current_user.username }}さんのマイページ編集画面</h1>
+
+{% endblock %}

--- a/myapp/templates/study_fields.html
+++ b/myapp/templates/study_fields.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %} 学習分野 {% endblock %}
+
+{% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="flashes">
+                {% for message in messages %}
+                    <p>{{ message }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    <h1>{{ current_user.username }}さんの学習分野</h1>
+
+{% endblock %}

--- a/myapp/templates/study_logs.html
+++ b/myapp/templates/study_logs.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %} 学習登録 {% endblock %}
+
+{% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="flashes">
+                {% for message in messages %}
+                    <p>{{ message }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    <h1>{{ current_user.username }}さんの学習登録</h1>
+
+{% endblock %}

--- a/myapp/templates/study_logs_list.html
+++ b/myapp/templates/study_logs_list.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %} 学習履歴一覧 {% endblock %}
+
+{% block content %}
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="flashes">
+                {% for message in messages %}
+                    <p>{{ message }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    <h1>{{ current_user.username }}さんの学習履歴一覧</h1>
+
+{% endblock %}

--- a/myapp/views.py
+++ b/myapp/views.py
@@ -37,7 +37,7 @@ def login_process():
         else:
             if check_password_hash(user.password, password):
                 login_user(user)
-                return redirect(url_for('index_view', user_id = user.user_id))
+                return redirect(url_for('index_view', user_id=user.user_id))
             else:
                 flash('異なるパスワードです')
                 return redirect(url_for('login_view'))
@@ -131,8 +131,40 @@ def password_reset_process():
             return redirect(url_for('login_view'))
     return redirect(url_for('password_reset_view'))
 
+# ーーーーーーーーーーーーーーーーーーー以降認証後画面ーーーーーーーーーーーーーーーーーーーーーーーーーーーー
+
 # ホーム画面表示
 @app.route('/index/<user_id>', methods=['GET'])
 @login_required
 def index_view(user_id):
     return render_template('index.html')
+
+# マイページ画面表示
+@app.route('/mypage/<user_id>', methods=['GET'])
+@login_required
+def mypage_view(user_id):
+    return render_template('mypage.html')
+
+# マイページ編集画面表示
+@app.route('/mypage-edit/<user_id>', methods=['GET'])
+@login_required
+def mypage_edit_view(user_id):
+    return render_template('mypage_edit.html')
+
+# 学習登録画面表示
+@app.route('/study-logs/<user_id>', methods=['GET'])
+@login_required
+def study_logs_view(user_id):
+    return render_template('study_logs.html')
+
+# 学習分野画面表示
+@app.route('/study-fields/<user_id>', methods=['GET'])
+@login_required
+def study_fields_view(user_id):
+    return render_template('study_fields.html')
+
+# 学習履歴一覧画面表示
+@app.route('/study-logs-list/<user_id>', methods=['GET'])
+@login_required
+def study_logs_list(user_id):
+    return render_template('study_logs_list.html')


### PR DESCRIPTION
画面遷移図を基に認証後の各画面へのルーティング設定を行った。
認証後の各画面のurlには<user_id>を付加して、ログインユーザーの専用ページとなるように設定した。 認証後の各画面を表示するため、mypage_edit.html,mypage.html,study_fields.html,study_logs_list.html,study_logs.htmlを追加した。