### PR TITLE
学習記録の編集・削除機能を追加

### DIFF
--- a/myapp/models.py
+++ b/myapp/models.py
@@ -47,8 +47,9 @@ class Field(db.Model):
     created_at = Column(TIMESTAMP, nullable=False, default=datetime.utcnow, server_default=func.now())
 
     # users,study_logsに紐づけし、双方向でアクセス
+    # study_logsとはcascade設定をし、fieldが削除されれば、関連するstudy_logsも削除するよう設定
     users = relationship('User', back_populates='fields')
-    study_logs = relationship('StudyLog', back_populates='fields')
+    study_logs = relationship('StudyLog', back_populates='fields', cascade='all, delete-orphan')
 
     def __init__(self, user_id, fieldname, color_code):
         self.user_id = user_id

--- a/myapp/templates/study_fields.html
+++ b/myapp/templates/study_fields.html
@@ -55,6 +55,10 @@
         <button type="submit">更新</button>
         <button type="button" onclick="addRow()">記入欄を追加する</button>
     </form>
+    
+    <div class="index">
+        <a href="{{ url_for('index_view', user_id=current_user.user_id) }}">ホーム</a>
+    </div>
 
     <script>
         function markDeleted(btn) {

--- a/myapp/templates/study_logs.html
+++ b/myapp/templates/study_logs.html
@@ -41,6 +41,11 @@
                             </datalist>
                         </td>
                         <td><textarea name="contents[]">{{ study_log.content or '' }}</textarea></td>
+                        <td>
+                            <input type="hidden" name="study_log_id[]" value="{{ study_log.study_log_id }}">
+                            <input type="hidden" name="row_action[]" value="update">
+                            <button type="button" onclick="markDeleted(this)">🗑️</button>
+                        </td>
                     </tr>
                 {% endfor %}
 
@@ -59,10 +64,31 @@
                         </datalist>
                     </td>
                     <td><textarea name="contents[]"></textarea></td>
+                    <td>
+                        <input type="hidden" name="study_log_id[]" value="">
+                        <input type="hidden" name="row_action[]" value="new">
+                        <button type="button" onclick="removeRow(this)">🗑️</button>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
         <button type="submit">更新</button>
+        <button type="button" onclick="addRow()">記入欄を追加する</button>
     </form>
+    
+    <div class="index">
+        <a href="{{ url_for('index_view', user_id=current_user.user_id) }}">ホーム</a>
+    </div>
+
+    <script>
+        function markDeleted(btn) {
+            const row = btn.closest('tr');
+            row.querySelector('input[name="row_action[]"]').value = 'delete';
+            row.style.opacity = 0.5;
+        };
+        function removeRow(btn) {
+            btn.closest('tr').remove();
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
昨日の学習記録の登録機能に加え、編集・削除機能を追加した。
登録・編集・削除でそれぞれフォームのactionを設定し、new,upgrade,deleteで条件分岐を行い、各処理を記述した。
また、学習分野が削除されれば、関連する学習記録が削除されるよう、models.pyのfieldsテーブルとstudy_logsテーブルをcascade='all, delete-orphan'で接続し、1対多の関係を構築した。