### PR TITLE
週間グラフを追加・表示

### DIFF
--- a/Docker/Flask/Dockerfile
+++ b/Docker/Flask/Dockerfile
@@ -8,6 +8,12 @@ ENV PYTHONUNBUFFERED=1
 # コンテナ内のワーキングディレクトリを指定
 WORKDIR /code
 
+# matplotlibの日本語対応のフォントパッケージを先にインストール
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    fonts-ipaexfont \
+    && rm -rf /var/lib/apt/lists/*
+
 # カレントディレクトリのrequirements.txtをワーキングディレクトリ直下にコピー
 # 依存関係ファイルのみ先にコピー（キャッシュ効率化のため）
 COPY requirements.txt .

--- a/myapp/models.py
+++ b/myapp/models.py
@@ -13,12 +13,12 @@ import base64
 import platform
 
 # matplotlibのフォント定義
-# font_path = '/usr/share/fonts/truetype/fonts-japanese-gothic.ttf'
-# font_prop = font_manager.FontProperties(fname=font_path)
-# plt.rcParams['font.family'] = font_prop.get_name()
+font_path = '/usr/share/fonts/truetype/fonts-japanese-gothic.ttf'
+font_prop = font_manager.FontProperties(fname=font_path)
+plt.rcParams['font.family'] = font_prop.get_name()
 
 # SVGグラフのフォントにテキストを埋め込み
-# plt.rcParams['svg.fonttype'] = 'none'
+plt.rcParams['svg.fonttype'] = 'none'
 
 # テーブル・カラム作成
 class User(UserMixin, db.Model):
@@ -210,12 +210,11 @@ class StudyLog(db.Model):
         ax.set_ylim(0, max(sum(zip(*data.values()), ())) + 1)
         ax.legend()
 
-        # 画像をbase64エンコードしてテンプレートに渡す
+        # 画像をsvg形式で生成する
         buf = io.BytesIO()
         plt.savefig(buf, format='svg')
-        buf.seek(0)
-        encoded = base64.b64encode(buf.read()).decode('utf-8')
+        svg_data = buf.getvalue()
         plt.close(fig)
 
-        return encoded
+        return svg_data
 

--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -54,18 +54,9 @@
             <p>今週の平均学習時間：{{ this_week_stats['average_per_day'] }}時間／日</p>
         </div>
         <div class="main-stats-graph">
-            {% if this_week_graph %}
-                <img src="data:image/svg+xml;base64,{{ this_week_graph }}" alt="学習グラフ">
-            {% else %}
-                <p>今週の学習記録がありません</p>
-            {% endif %}
+            <iframe src="{{ url_for('graph_svg', user_id=current_user.user_id) }}" width="100%" height="400" frameborder="0"></iframe>
         </div>
     </div>
-
-
-
-
-
 </main>
 
 {% endblock %}

--- a/myapp/views.py
+++ b/myapp/views.py
@@ -1,4 +1,4 @@
-from flask import request, render_template, redirect, url_for, flash
+from flask import request, render_template, redirect, url_for, flash, Response
 from flask_login import login_user, login_required, logout_user, current_user
 from flask_bcrypt import generate_password_hash, check_password_hash
 from sqlalchemy.exc import IntegrityError
@@ -152,8 +152,14 @@ def index_view(user_id):
         total_hour = total_hour,
         total_day = total_day,
         this_week_stats = this_week_stats,
-        this_week_graph = this_week_graph
     )
+
+@app.route('/graph/<user_id>', methods=['GET'])
+def graph_svg(user_id):
+    svg = StudyLog.get_this_week_graph(user_id)
+    if svg:
+        return Response(svg, mimetype='image/svg+xml')
+    return Response(status=204)
 
 # マイページ画面表示
 @app.route('/mypage/<user_id>', methods=['GET'])


### PR DESCRIPTION
matplotlibを使用して、今週の学習記録のグラフを追加・表示できるようにした。
matplotlibが日本語フォントに対応できるよう、FlaskのDockerfileにfontのパッケージをインポートした。
画像はsvg形式として表示し、埋め込み画像ではなく、テキストを選択できるよう、svg+xmlとした。