### PR TITLE
分野別グラフ取得のメソッド追加、月間・年間の学習情報取得メソッド追加

### DIFF
--- a/myapp/models.py
+++ b/myapp/models.py
@@ -107,17 +107,17 @@ class StudyLog(db.Model):
     def get_study_logs_all(cls, user_id):
         return cls.query.filter_by(user_id=user_id).all()
 
+    # 学習総日数取得
+    @classmethod
+    def get_total_day(cls, user_id):
+        total_day = db.session.query(func.count(func.distinct(cls.study_date))).filter_by(user_id=user_id).scalar()
+        return int(total_day or 0)
+    
     # 学習総時間取得
     @classmethod
     def get_total_hour(cls, user_id):
         total_hour = db.session.query(func.sum(cls.hour)).filter_by(user_id=user_id).scalar()
         return float(total_hour or 0.0)
-    
-    # 学習総日数取得
-    @classmethod
-    def get_total_day(cls, user_id):
-        total_day = db.session.query(func.count(cls.study_date)).filter_by(user_id=user_id).scalar()
-        return int(total_day or 0)
     
     # 今週の学習時間（合計、平均）、学習日数の取得
     @classmethod
@@ -158,7 +158,7 @@ class StudyLog(db.Model):
         return {
             'start_date': start_of_week,
             'end_date': end_of_week,
-            'total_hours': total_hours,
+            'total_hours': float(total_hours or 0.0),
             'study_days': study_days,
             'average_per_day': round(average_per_day, 2)
         }
@@ -226,6 +226,42 @@ class StudyLog(db.Model):
 
         return svg_data
 
+    # 月間学習日数、学習時間（合計）、学習時間（平均）の取得
+    @classmethod
+    def get_month_stats(cls, user_id, month_str):
+        year, month = map(int, month_str.split('-'))
+        first_day = date(year, month, 1)
+        month_num = calendar.monthrange(year, month)[1]
+        last_day = date(year, month, month_num)
+
+        total_hours = (
+            db.session.query(func.sum(cls.hour))
+            .filter(
+                cls.user_id == user_id,
+                cls.study_date >= first_day,
+                cls.study_date <= last_day
+            )
+            .scalar()
+        )
+
+        study_days = (
+            db.session.query(func.count(func.distinct(cls.study_date)))
+            .filter(
+                cls.user_id == user_id,
+                cls.study_date >= first_day,
+                cls.study_date <= last_day
+            )
+            .scalar()
+        )
+
+        average_per_day = total_hours / study_days if study_days else 0.0
+
+        return {
+            'total_hours': float(total_hours or 0.0),
+            'study_days': study_days,
+            'average_per_day': round(average_per_day, 1)
+        }
+
     # 月間グラフ作成
     @classmethod
     def get_month_graph(cls, user_id, month_str):
@@ -276,7 +312,6 @@ class StudyLog(db.Model):
         ax.set_ylim(0, ymax)
         ax.legend(loc='upper left', bbox_to_anchor=(1, 1))
 
-        # 画像をsvg形式で生成する
         buf = io.BytesIO()
         plt.tight_layout()
         plt.savefig(buf, format='svg')
@@ -284,7 +319,42 @@ class StudyLog(db.Model):
         plt.close(fig)
 
         return svg_data
-    
+
+    # 年間学習日数、学習時間（合計）、学習時間（平均）の取得
+    @classmethod
+    def get_year_stats(cls, user_id, year_str):
+        year = int(year_str)
+        first_day = date(year, 1, 1)
+        last_day= date(year, 12, 31)
+
+        total_hours = (
+            db.session.query(func.sum(cls.hour))
+            .filter(
+                cls.user_id == user_id,
+                cls.study_date >= first_day,
+                cls.study_date <= last_day
+            )
+            .scalar()
+        )
+
+        study_days = (
+            db.session.query(func.count(func.distinct(cls.study_date)))
+            .filter(
+                cls.user_id == user_id,
+                cls.study_date >= first_day,
+                cls.study_date <= last_day
+            )
+            .scalar()
+        )
+
+        average_per_day = total_hours / study_days if study_days else 0.0
+
+        return {
+            'total_hours': float(total_hours or 0.0),
+            'study_days': study_days,
+            'average_per_day': round(average_per_day, 1)
+        }
+
     # 年間グラフの作成
     @classmethod
     def get_year_graph(cls, user_id, year_str):

--- a/myapp/templates/index.html
+++ b/myapp/templates/index.html
@@ -39,20 +39,20 @@
 
 <main>
     <div class="head-stats">
+        <div class="head-stats-totalday">
+            <p>学習日数</p>
+            <p>{{ total_day }}日</p>
+        </div>
         <div class="head-stats-totalhour">
-            <p>学習総時間</p>
+            <p>学習時間（合計）</p>
             <p>{{ total_hour }}時間</p>
         </div>
-        <div class="head-stats-totalday">
-            <p>学習総日数</p>
-            <p>{{ total_day }}日</p>
+        <div class="head-stats-avghour">
+            <p>学習時間（平均）</p>
+            <p>{{ avg_hour }}時間/日</p>
         </div>
     </div>
     <div class="main-stats">
-        <div class="main-stats-hour">
-            <p>今週の合計学習時間：{{ this_week_stats['total_hours'] }}時間／週</p>
-            <p>今週の平均学習時間：{{ this_week_stats['average_per_day'] }}時間／日</p>
-        </div>
         <div class="main-stats-graph">
             <iframe src="{{ url_for('graph_svg', user_id=current_user.user_id) }}" width="100%" height="400" frameborder="0"></iframe>
         </div>

--- a/myapp/views.py
+++ b/myapp/views.py
@@ -138,27 +138,41 @@ def password_reset_process():
 @app.route('/index/<user_id>', methods=['GET'])
 @login_required
 def index_view(user_id):
-    # 学習総時間の取得
-    total_hour = StudyLog.get_total_hour(user_id)
-    # 学習総日数取得
+    # 学習日数取得
     total_day = StudyLog.get_total_day(user_id)
-    # 今週の学習時間（合計、平均）、学習日数の取得
-    this_week_stats = StudyLog.get_this_week_stats(user_id)
-    # 今週の学習グラフの取得
-    this_week_graph = StudyLog.get_this_week_graph(user_id)
+    # 学習時間（合計）の取得
+    total_hour = StudyLog.get_total_hour(user_id)
+    # 学習時間（平均）の取得
+    avg_hour = round(total_hour / total_day, 1)
 
     return render_template(
         'index.html',
-        total_hour = total_hour,
         total_day = total_day,
-        this_week_stats = this_week_stats,
+        total_hour = total_hour,
+        avg_hour = avg_hour
     )
 
-@app.route('/graph/<user_id>', methods=['GET'])
+@app.route('/graph/<user_id>', methods=['GET', 'POST'])
 def graph_svg(user_id):
-    svg = StudyLog.get_this_week_graph(user_id)
-    if svg:
-        return Response(svg, mimetype='image/svg+xml')
+    # 今週の学習グラフの取得（積み上げ縦棒）
+    this_week_graph = StudyLog.get_this_week_graph(user_id)
+    # 月間グラフの取得（積み上げ縦棒）
+
+    # 年間グラフの取得（積み上げ縦棒）
+
+    # 分野別全期間グラフの取得
+    all_time_graph_by_field = StudyLog.get_all_time_graph_by_field(user_id)
+
+    # 分野別年間グラフの取得
+
+    # 分野別月間グラフの取得
+
+
+    # if this_week_graph:
+    #     return Response(this_week_graph, mimetype='image/svg+xml')
+    if all_time_graph_by_field:
+        return Response(all_time_graph_by_field, mimetype='image/svg+xml')
+
     return Response(status=204)
 
 # マイページ画面表示


### PR DESCRIPTION
主な修正ファイルはmodels.pyである。
学習分野別に学習時間を表示するグラフを追加した。
期間は、全期間・年間・月間でそれぞれ作成している。
また、月間・年間の学習情報取得メソッドも追加し、ユーザーが表示したい月・年における学習日数、学習時間（合計）、学習時間（平均）を返すメソッドとなっている。