### PR TITLE
学習記録の登録・編集に日付に応じて学習記録が変化する機能、記入欄の追加機能を追加

### DIFF
--- a/myapp/models.py
+++ b/myapp/models.py
@@ -107,6 +107,12 @@ class StudyLog(db.Model):
     def get_study_logs_all(cls, user_id):
         return cls.query.filter_by(user_id=user_id).all()
 
+    # 学習日に応じたユーザー毎の学習履歴取得
+    @classmethod
+    def get_study_logs_by_study_date(cls, user_id, date_str):
+        study_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        return cls.query.filter_by(user_id=user_id, study_date=study_date).all()
+
     # 学習総日数取得
     @classmethod
     def get_total_day(cls, user_id):

--- a/myapp/static/js/common.js
+++ b/myapp/static/js/common.js
@@ -1,1 +1,13 @@
-// 共通作業：モータルウィンドウの開閉、ハンバーガーメニューの開閉、エラーメッセージの表示・自動削除
+// 共通動作：行の削除、モータルウィンドウの開閉、ハンバーガーメニューの開閉、エラーメッセージの表示・自動削除等
+
+// 既存行の削除
+const markDeleted = (btn) => {
+    const row = btn.closest('tr');
+    row.querySelector('input[name="row_action[]"]').value = 'delete';
+    row.style.opacity = 0.5;
+};
+
+// 空白行の削除
+const removeRow = (btn) => {
+    btn.closest('tr').remove();
+}

--- a/myapp/static/js/study_fields.js
+++ b/myapp/static/js/study_fields.js
@@ -1,16 +1,4 @@
-// study_fields, study_logsの共通動作
-
-// 既存行の削除
-const markDeleted = (btn) => {
-    const row = btn.closest('tr');
-    row.querySelector('input[name="row_action[]"]').value = 'delete';
-    row.style.opacity = 0.5;
-};
-
-// 空白行の削除
-const removeRow = (btn) => {
-    btn.closest('tr').remove();
-}
+// study_fieldsの動作
 
 // 学習分野の新しい行の追加
 const addRowFields = (btn) => {
@@ -25,11 +13,6 @@ const addRowFields = (btn) => {
     <input type="hidden" name="field_id[]" value="">
     <input type="hidden" name="row_action[]" value="new">
     <button class="delete-button" type="button" onclick="removeRow(this)">🗑️</button>
-    </td>`
+    </td>`;
     table.appendChild(newRow);
-}
-
-// 学習記録の新しい行の追加
-const addRowLogs = (btn) >= {
-    
 }

--- a/myapp/static/js/study_logs.js
+++ b/myapp/static/js/study_logs.js
@@ -1,0 +1,35 @@
+// study_logsの動作
+
+// 日付を動的に表示
+document.addEventListener('DOMContentLoaded', () => {
+    const dateInput = document.getElementById('study_date');
+    const form = document.getElementById('study-date-form');
+
+    dateInput.addEventListener('change', () => {
+        form.submit();
+    })
+});
+
+// 学習記録の新しい行の追加
+const addRowLogs = (btn) => {
+    const table = document.getElementById('study-logs');
+    const newRow = document.createElement('tr');
+    const rowNum = table.rows.length;
+    const selected_date = document.getElementById('selected_date');
+    const date = selected_date.dataset.selectedDate;
+
+    newRow.innerHTML = `
+    <td class="table-num">${rowNum}</td>
+    <td><input type="number" step="0.1" min="0" max="24" name="hours[]" value=""></td>
+    <td>
+        <input type="text" name="fieldname[]" value="" list="field_list2">
+    </td>
+    <td><textarea name="contents[]"></textarea></td>
+    <td>
+        <input type="hidden" name="study_dates[]" value="${date}">
+        <input type="hidden" name="study_log_id[]" value="">
+        <input type="hidden" name="row_action[]" value="new">
+        <button class="delete-button" type="button" onclick="removeRow(this)">🗑️</button>
+    </td>`;
+    table.appendChild(newRow);
+}

--- a/myapp/templates/study_fields.html
+++ b/myapp/templates/study_fields.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% block head_link %}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/study.css') }}">
-    <script src="{{ url_for('static', filename='js/study_edit.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/common.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/study_fields.js') }}"></script>
 {% endblock %}
 
 {% block title %} 学習分野の登録・編集 {% endblock %}

--- a/myapp/templates/study_logs.html
+++ b/myapp/templates/study_logs.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% block head_link %}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/study.css') }}">
-    <script src="{{ url_for('static', filename='js/study_edit.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/common.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/study_logs.js') }}"></script>
 {% endblock %}
 
 {% block title %} 学習記録の登録・編集 {% endblock %}
@@ -36,15 +37,23 @@
     <div class="study-inner">
         <div class="study-head">
             <h1>学習記録の登録・編集</h1>
+            <p>{{ selected_date }}</p>
         </div>
+        <!-- 画面表示時のフォーム -->
+        <div class="study-date">
+            <form action="{{ url_for('study_logs_view', user_id=current_user.user_id) }}" method="post" id="study-date-form">
+                <label for="study_date">日付：</label>
+                <input type="date" name="study_date" id="study_date" value="{{ selected_date }}">
+            </form>
+        </div>
+        <!-- 学習記録登録・編集時のフォーム -->
         <div class="study-form">
             <form class="study_logs_process" action="{{ url_for('study_logs_process', user_id=current_user.user_id) }}" method="post">
                 <div class="study-table">
-                <table>
+                <table id="study-logs">
                     <thead>
                         <tr>
                             <th>No.</th>
-                            <th>日付</th>
                             <th>学習時間</th>
                             <th>分野名</th>
                             <th>内容</th>
@@ -53,11 +62,10 @@
                     </thead>
                     <tbody>
                         <!-- 学習ログがある場合はループで表示 -->
-                        {% for study_log in current_user.study_logs %}
+                        {% for study_log in study_logs %}
                             <tr>
                                 <td class="table-num">{{ loop.index }}</td>
-                                <td><input type="date" name="study_dates[]" value="{{ study_log.study_date or '' }}"></td>
-                                <td><input type="number" step="0.1" min="0" max="24" name="hours[]" value="{{ study_log.hour or '' }}"></td>
+                                <td><input type="number" step="0.1" min="0" max="24" name="hours[]" value="{{ study_log.hour }}"></td>
                                 <td>
                                     <input type="text" name="fieldname[]" value="{{ study_log.fields.fieldname }}" list="field_list">
                                     <datalist id="field_list">
@@ -66,8 +74,9 @@
                                         {% endfor %}
                                     </datalist>
                                 </td>
-                                <td><textarea name="contents[]">{{ study_log.content or '' }}</textarea></td>
+                                <td><textarea name="contents[]">{{ study_log.content }}</textarea></td>
                                 <td>
+                                    <input type="hidden" name="study_dates[]" value="{{ selected_date }}">
                                     <input type="hidden" name="study_log_id[]" value="{{ study_log.study_log_id }}">
                                     <input type="hidden" name="row_action[]" value="update">
                                     <button class="delete-button" type="button" onclick="markDeleted(this)">🗑️</button>
@@ -76,14 +85,13 @@
                         {% endfor %}
 
                         <!-- 空行の記入欄の表示（デフォルトでは5行表示） -->
-                        {% for i in range(3) %}
+                        {% for i in range(5 - study_logs|length) %}
                         <tr>
-                            <td class="table-num">{{ current_user.study_logs|length + i + 1 }}</td>
-                            <td><input type="date" name="study_dates[]" value=""></td>
+                            <td class="table-num">{{ study_logs|length + i + 1 }}</td>
                             <td><input type="number" step="0.1" min="0" max="24" name="hours[]" value=""></td>
                             <td>
                                 <input type="text" name="fieldname[]" value="" list="field_list2">
-                                <datalist id="field_list2">
+                                <datalist id="field_list2" data-fieldname="{{ current_user.fields }}">
                                     {% for field in current_user.fields %}
                                     <option value="{{ field.fieldname }}"></option>
                                     {% endfor %}
@@ -91,6 +99,7 @@
                             </td>
                             <td><textarea name="contents[]"></textarea></td>
                             <td>
+                                <input type="hidden" name="study_dates[]" id="selected_date" data-selected-date="{{ selected_date }}">
                                 <input type="hidden" name="study_log_id[]" value="">
                                 <input type="hidden" name="row_action[]" value="new">
                                 <button class="delete-button" type="button" onclick="removeRow(this)">🗑️</button>


### PR DESCRIPTION
学習記録の表示画面が日付に応じて変化するようJSを修正した。
また、記入欄の追加機能もJSに記載した。
初期画面では、本日の日付が表示され、カレンダーから日付を選択するとformが自動で送信され、表示内容が日付に応じたものに変化する。